### PR TITLE
Automerge lock file maintenance PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,9 @@
     "enabled": true,
     "branchTopic": "lock-file-maintenance-{{packageFile}}",
     "commitMessageExtra": "({{packageFile}})",
-    "minimumReleaseAgeBehaviour": "timestamp-optional"
+    "minimumReleaseAgeBehaviour": "timestamp-optional",
+    "automerge": true,
+    "automergeType": "branch"
   },
   "major": {
     "automerge": false


### PR DESCRIPTION
## Summary
- Set `automerge: true` and `automergeType: "branch"` on `lockFileMaintenance` so renovate merges these directly when checks pass (matching the existing app/calendar-api minor/patch automerge config)

## Test plan
- [ ] Renovate validates the config on next run; confirm a lock-file-maintenance branch is automerged